### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(name = 'minepy',
       install_requires = ['numpy >= 1.3.0'],
       classifiers=classifiers,
       ext_modules=ext_modules,
-      use_2to3=True,
+      use_2to3=False,
       cmdclass = {'build_ext': build_ext_custom}
     )


### PR DESCRIPTION
As python2 is no longer supported, setuptools since version 58 dropped support for use_2to3 Flag, so when building this package, setuptools raises an error and won't allow minepy installation.

Therefore, I set use_2to3=False so minepy will build approprietaly from now.

Sorry for my poor english.